### PR TITLE
Expand aliases to their full cmdlet/function names

### DIFF
--- a/SCSM-Get-SCSMUserManager/Get-SCSMUserManager.ps1
+++ b/SCSM-Get-SCSMUserManager/Get-SCSMUserManager.ps1
@@ -10,7 +10,7 @@
     ## MAIN
     $affectedUser_obj = get-scsmobject -id $input_affectedUser_id
     $userManagesUser_relclass_id = '4a807c65-6a1f-15b2-bdf3-e967e58c254a'
-    $managerOfAffectedUser_relobjs = Get-SCSMRelationshipObject -ByTarget $affectedUser_obj | where{ $_.relationshipId -eq $userManagesUser_relclass_id }
+    $managerOfAffectedUser_relobjs = Get-SCSMRelationshipObject -ByTarget $affectedUser_obj | Where-Object{ $_.relationshipId -eq $userManagesUser_relclass_id }
 
     ## Check if Manager User Exists and that the relationship is current.
     ##  get-scsmrelationshipobject tends to keep track of relationship history. It returns old and new

--- a/SCSM-Get-SCSMWorkItemChildItem/Get-SCSMWorkItemChildItem.ps1
+++ b/SCSM-Get-SCSMWorkItemChildItem/Get-SCSMWorkItemChildItem.ps1
@@ -11,7 +11,7 @@
 	$inputPWI_obj = get-scsmobject -id $inputPWI_guid
 	$containsActivity_relclass_id = '2da498be-0485-b2b2-d520-6ebd1698e61b'
 	$childWIs_relobj_filter = "RelationshipId -eq '$containsActivity_relclass_id'"
-	$childWIs_relobj = Get-SCSMRelationshipObject -BySource $inputPWI_obj | where{ $_.RelationshipId -eq $containsActivity_relclass_id }
+	$childWIs_relobj = Get-SCSMRelationshipObject -BySource $inputPWI_obj | Where-Object{ $_.RelationshipId -eq $containsActivity_relclass_id }
 	ForEach ($childWI_relobj in $childWIs_relobj)
 	{
 		if ($childWI_relobj.IsDeleted -ne 'false')

--- a/TOOL-Invoke-Ping/Invoke-Ping.ps1
+++ b/TOOL-Invoke-Ping/Invoke-Ping.ps1
@@ -1,4 +1,4 @@
-Function Invoke-Ping
+﻿Function Invoke-Ping
 {
 <#
 .SYNOPSIS
@@ -147,12 +147,12 @@ Function Invoke-Ping
                     $StandardUserEnv = [powershell]::Create().addscript({
 
                         #Get modules and snapins in this clean runspace
-                        $Modules = Get-Module | Select -ExpandProperty Name
-                        $Snapins = Get-PSSnapin | Select -ExpandProperty Name
+                        $Modules = Get-Module | Select-Object -ExpandProperty Name
+                        $Snapins = Get-PSSnapin | Select-Object -ExpandProperty Name
 
                         #Get variables in this clean runspace
                         #Called last to get vars like $? into session
-                        $Variables = Get-Variable | Select -ExpandProperty Name
+                        $Variables = Get-Variable | Select-Object -ExpandProperty Name
 
                         #Return a hashtable where we can access each.
                         @{
@@ -167,22 +167,22 @@ Function Invoke-Ping
                         #Exclude common parameters, bound parameters, and automatic variables
                         Function _temp { [cmdletbinding()]
                             param () }
-                        $VariablesToExclude = @((Get-Command _temp | Select -ExpandProperty parameters).Keys + $PSBoundParameters.Keys + $StandardUserEnv.Variables)
-                        Write-Verbose "Excluding variables $(($VariablesToExclude | sort) -join ", ")"
+                        $VariablesToExclude = @((Get-Command _temp | Select-Object -ExpandProperty parameters).Keys + $PSBoundParameters.Keys + $StandardUserEnv.Variables)
+                        Write-Verbose "Excluding variables $(($VariablesToExclude | Sort-Object) -join ", ")"
 
                         # we don't use 'Get-Variable -Exclude', because it uses regexps.
                         # One of the veriables that we pass is '$?'.
                         # There could be other variables with such problems.
                         # Scope 2 required if we move to a real module
-                        $UserVariables = @(Get-Variable | Where { -not ($VariablesToExclude -contains $_.Name) })
-                        Write-Verbose "Found variables to import: $(($UserVariables | Select -expandproperty Name | Sort) -join ", " | Out-String).`n"
+                        $UserVariables = @(Get-Variable | Where-Object { -not ($VariablesToExclude -contains $_.Name) })
+                        Write-Verbose "Found variables to import: $(($UserVariables | Select-Object -expandproperty Name | Sort-Object) -join ", " | Out-String).`n"
 
                     }
 
                     if ($ImportModules)
                     {
-                        $UserModules = @(Get-Module | Where { $StandardUserEnv.Modules -notcontains $_.Name -and (Test-Path $_.Path -ErrorAction SilentlyContinue) } | Select -ExpandProperty Path)
-                        $UserSnapins = @(Get-PSSnapin | Select -ExpandProperty Name | Where { $StandardUserEnv.Snapins -notcontains $_ })
+                        $UserModules = @(Get-Module | Where-Object { $StandardUserEnv.Modules -notcontains $_.Name -and (Test-Path $_.Path -ErrorAction SilentlyContinue) } | Select-Object -ExpandProperty Path)
+                        $UserSnapins = @(Get-PSSnapin | Select-Object -ExpandProperty Name | Where-Object { $StandardUserEnv.Snapins -notcontains $_ })
                     }
                 }
 
@@ -220,7 +220,7 @@ Function Invoke-Ping
                             $runMin = [math]::Round($runtime.totalminutes, 2)
 
                             #set up log object
-                            $log = "" | select Date, Action, Runtime, Status, Details
+                            $log = "" | Select-Object Date, Action, Runtime, Status, Details
                             $log.Action = "Removing:'$($runspace.object)'"
                             $log.Date = $currentdate
                             $log.Runtime = "$runMin minutes"
@@ -295,7 +295,7 @@ Function Invoke-Ping
 
                         #Clean out unused runspace jobs
                         $temphash = $runspaces.clone()
-                        $temphash | Where { $_.runspace -eq $Null } | ForEach {
+                        $temphash | Where-Object { $_.runspace -eq $Null } | ForEach-Object {
                             $Runspaces.remove($_)
                         }
 
@@ -345,7 +345,7 @@ Function Invoke-Ping
                                 [void]$list.Add($Ast.SubExpression)
                             }
 
-                            $UsingVar = $UsingVariables | Group Parent | ForEach { $_.Group | Select -First 1 }
+                            $UsingVar = $UsingVariables | Group-Object Parent | ForEach-Object { $_.Group | Select-Object -First 1 }
 
                             #Extract the name, value, and create replacements for each
                             $UsingVariableData = ForEach ($Var in $UsingVar)
@@ -440,11 +440,11 @@ Function Invoke-Ping
                 if ($LogFile)
                 {
                     New-Item -ItemType file -path $logFile -force | Out-Null
-                    ("" | Select Date, Action, Runtime, Status, Details | ConvertTo-Csv -NoTypeInformation -Delimiter ";")[0] | Out-File $LogFile
+                    ("" | Select-Object Date, Action, Runtime, Status, Details | ConvertTo-Csv -NoTypeInformation -Delimiter ";")[0] | Out-File $LogFile
                 }
 
                 #write initial log entry
-                $log = "" | Select Date, Action, Runtime, Status, Details
+                $log = "" | Select-Object Date, Action, Runtime, Status, Details
                 $log.Date = Get-Date
                 $log.Action = "Batch processing started"
                 $log.Runtime = $null
@@ -557,7 +557,7 @@ Function Invoke-Ping
                         #endregion add scripts to runspace pool
                     }
 
-                    Write-Verbose ("Finish processing the remaining runspace jobs: {0}" -f (@($runspaces | Where { $_.Runspace -ne $Null }).Count))
+                    Write-Verbose ("Finish processing the remaining runspace jobs: {0}" -f (@($runspaces | Where-Object { $_.Runspace -ne $Null }).Count))
                     Get-RunspaceData -wait
 
                     if (-not $quiet)
@@ -728,7 +728,7 @@ Function Invoke-Ping
                                 {
                                     $DNSEntity = [Net.Dns]::GetHostEntry($name)
                                     $domain = ($DNSEntity.hostname).replace("$name.", "")
-                                    $ips = $DNSEntity.AddressList | %{
+                                    $ips = $DNSEntity.AddressList | ForEach-Object{
                                         if (-not (-not $IPV6 -and $_.AddressFamily -like "InterNetworkV6"))
                                         {
                                             $_.IPAddressToString
@@ -737,7 +737,7 @@ Function Invoke-Ping
                                 }
                                 catch
                                 {
-                                    $rst = New-Object -TypeName PSObject -Property $Hash | Select -Property $props
+                                    $rst = New-Object -TypeName PSObject -Property $Hash | Select-Object -Property $props
                                     $rst.name = $name
                                     $results += $rst
                                     $failed = 1
@@ -748,7 +748,7 @@ Function Invoke-Ping
                                     foreach ($ip in $ips)
                                     {
 
-                                        $rst = New-Object -TypeName PSObject -Property $Hash | Select -Property $props
+                                        $rst = New-Object -TypeName PSObject -Property $Hash | Select-Object -Property $props
                                         $rst.name = $name
                                         $rst.ip = $ip
                                         $rst.domain = $domain
@@ -832,7 +832,7 @@ Function Invoke-Ping
                                                         $w = [wmi] ''
                                                         $w.psbase.options.timeout = 15000000
                                                         $w.path = "\\$Name\root\cimv2:Win32_ComputerSystem.Name='$Name'"
-                                                        $w | select none | Out-Null
+                                                        $w | Select-Object none | Out-Null
                                                         $rst.RPC = $true
                                                     }
                                                     catch
@@ -897,8 +897,8 @@ Function Invoke-Ping
                             $detail = "WSMan", "RemoteReg", "RPC", "RDP", "SMB"
                         }
 
-                        $detail | Select -Unique | Foreach-Object { $TestServerParams.add($_, $True) }
-                        Test-Server @TestServerParams | Select -Property $("Name", "IP", "Domain", "Ping" + $detail)
+                        $detail | Select-Object -Unique | Foreach-Object { $TestServerParams.add($_, $True) }
+                        Test-Server @TestServerParams | Select-Object -Property $("Name", "IP", "Domain", "Ping" + $detail)
                     }
                     Catch
                     {
@@ -914,7 +914,7 @@ Function Invoke-Ping
                         $result = $null
                         if ($result = @(Test-Connection -ComputerName $computer -Count 2 -erroraction Stop))
                         {
-                            $Output = $result | Select -first 1 -Property Address,
+                            $Output = $result | Select-Object -first 1 -Property Address,
                                                        IPV4Address,
                                                        IPV6Address,
                                                        ResponseTime,
@@ -948,7 +948,7 @@ Function Invoke-Ping
                                 $status = "Error: $_"
                             }
 
-                            "" | Select -Property @{ label = "Address"; expression = { $computer } },
+                            "" | Select-Object -Property @{ label = "Address"; expression = { $computer } },
                                         IPV4Address,
                                         IPV6Address,
                                         ResponseTime,

--- a/TOOL-Out-Excel/Out-Excel.ps1
+++ b/TOOL-Out-Excel/Out-Excel.ps1
@@ -43,11 +43,11 @@
 				$property = @()
 				if ($raw)
 				{
-					$_.properties.PropertyNames | %{ $property += @($_) }
+					$_.properties.PropertyNames | ForEach-Object{ $property += @($_) }
 				}
 				else
 				{
-					$_.PsObject.get_properties() | % { $property += @($_.Name.ToString()) }
+					$_.PsObject.get_properties() | ForEach-Object { $property += @($_.Name.ToString()) }
 				}
 			}
 			$Column = 1

--- a/_Profiles/functions/Find-Apartment.ps1
+++ b/_Profiles/functions/Find-Apartment.ps1
@@ -1,4 +1,4 @@
-Function Find-Apartment
+﻿Function Find-Apartment
 {
 	<#
 	.SYNOPSIS
@@ -16,7 +16,7 @@ Function Find-Apartment
     $AvailableRooms = @()
     For ($CurrentPage=0;$CurrentPage -le $MaxPages;$CurrentPage++) {
         $WebPage = Invoke-WebRequest "$URL/search/roo?=roo&s=$Start&query=&zoomToPosting=&minAsk=$MinPrice&maxAsk=$MaxPrice&hasPic=1"
-        $Results = $WebPage.ParsedHtml.body.innerHTML.Split("`n") | ? { $_ -like "<P class=row*" }
+        $Results = $WebPage.ParsedHtml.body.innerHTML.Split("`n") | Where-Object { $_ -like "<P class=row*" }
         ForEach ($Item in $Results) {
             $ItemObject=$ID=$Price=$DatePosted=$Neighborhood=$Link=$Description=$Email=$null
             $ID = ($Item -replace ".*pid\=`"","") -replace "`".*"
@@ -25,7 +25,7 @@ Function Find-Apartment
             $Neighborhood = ($Item -replace ".*\<SMALL\>\(","") -replace "\)\</SMALL>.*"
             If ($Neighborhood -like "<*") { $Neighborhood = "N/A" }
             $Link = $URL + ((($Item -replace ".*\<A href\=`"","") -replace "\<.*") -split('">'))[0]
-            $Email = (($(Invoke-WebRequest $Link).ParsedHtml.body.innerHTML.Split("`n") | ? { $_ -like "var displayEmail*" }) -replace "var displayEmail \= `"") -replace "`";"
+            $Email = (($(Invoke-WebRequest $Link).ParsedHtml.body.innerHTML.Split("`n") | Where-Object { $_ -like "var displayEmail*" }) -replace "var displayEmail \= `"") -replace "`";"
             $Description = ((($Item -replace ".*\<A href\=`"","") -replace "\<.*") -split('">'))[1]
             $ItemObject = New-Object -TypeName PSObject -Property @{
                 'ID' = $ID

--- a/_Profiles/functions/show-object.ps1
+++ b/_Profiles/functions/show-object.ps1
@@ -35,7 +35,7 @@ Add-Type -Assembly System.Windows.Forms
 ## Figure out the variable name to use when displaying the
 ## object navigation syntax. To do this, we look through all
 ## of the variables for the one with the same object identifier.
-$rootVariableName = dir variable:\* -Exclude InputObject,Args |
+$rootVariableName = Get-ChildItem variable:\* -Exclude InputObject,Args |
     Where-Object {
         $_.Value -and
         ($_.Value.GetType() -eq $InputObject.GetType()) -and
@@ -43,7 +43,7 @@ $rootVariableName = dir variable:\* -Exclude InputObject,Args |
 }
 
 ## If we got multiple, pick the first
-$rootVariableName = $rootVariableName| % Name | Select -First 1
+$rootVariableName = $rootVariableName| ForEach-Object Name | Select-Object -First 1
 
 ## If we didn't find one, use a default name
 if(-not $rootVariableName)


### PR DESCRIPTION
This is a PR to expand all aliases into their full cmdlet/function names

For reference I ran the command `Invoke-ScriptAnalyzer -Path . -IncludeRule PSAvoidUsingCmdletAliases -Recurse -Fix`

Fixes #11 